### PR TITLE
Rust optimizations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@
 extern crate test;
 extern crate core;
 
-use std::cmp::Ordering;
 use core::str::StrExt;
 
 #[derive(Clone)]
@@ -14,14 +13,9 @@ pub struct Entity {
 
 fn render(text: &str, entities: &mut Vec<Entity>) -> String {
 	let mut sb = String::new();
-	entities.sort_by(|e1, e2| if e1.start < e2.start {
-		Ordering::Less
-	} else if e1.start > e2.start {
-		Ordering::Greater
-	} else {
-		Ordering::Equal
-	});
-	let mut pos = 0 as usize;
+	entities.sort_by(|e1, e2| e1.start.cmp(&e2.start) );
+
+  let mut pos = 0 as usize;
 	for entity in entities {
 		sb.push_str(text.slice_chars(pos, entity.start));
 		sb.push_str(entity.html.as_str());

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,50 +1,89 @@
-#![feature(convert, test, core, core_str_ext)]
+#![feature(convert, test, core, core_str_ext, vec_push_all)]
 extern crate test;
 extern crate core;
 
 use core::str::StrExt;
 
+pub static ASCII_TEXT: &'static str = "Attend to hear 6 stellar #mobile #startups at #OF12 Entrepreneur Idol show 2day,  http://t.co/HtzEMgAC @TiEcon @sv_entrepreneur @500!";
+pub static UNICODE_TEXT: &'static str = "Attend 次次 hear 6 stellar #mobile #startups at #OF12 Entrepreneur Idol show 2day,  http://t.co/HtzEMgAC @TiEcon @sv_entrepreneur @500!";
+
 #[derive(Clone)]
 pub struct Entity {
     start: usize,
-	end: usize,
+    end: usize,
     html: String
 }
 
-fn render(text: &str, entities: &mut Vec<Entity>) -> String {
-	let mut sb = String::new();
-	entities.sort_by(|e1, e2| e1.start.cmp(&e2.start) );
-
-  let mut pos = 0 as usize;
-	for entity in entities {
-		sb.push_str(text.slice_chars(pos, entity.start));
-		sb.push_str(entity.html.as_str());
-		pos = entity.end;
-	}
-	sb.push_str(text.slice_chars(pos, text.len()));
-	sb
+#[derive(Clone)]
+pub struct DecodedEntity {
+    start: usize,
+    end: usize,
+    html: Vec<char>,
 }
+
+unsafe fn render_ascii(text: &str, entities: &mut Vec<Entity>) -> String {
+    let mut sb = String::new();
+    entities.sort_by(|e1, e2| e1.start.cmp(&e2.start) );
+
+    let mut pos = 0 as usize;
+    for entity in entities {
+        sb.push_str(text.slice_unchecked(pos, entity.start));
+        sb.push_str(entity.html.as_str());
+        pos = entity.end;
+    }
+    sb.push_str(text.slice_unchecked(pos, text.len()));
+    sb
+}
+
+fn render(text: &Vec<char>, entities: &mut Vec<DecodedEntity>) -> String {
+    // Initial capacity based on observation that entities tend to add just 2 chars
+    let mut sb: Vec<char> = Vec::with_capacity(text.len()+entities.len()*2);
+    entities.sort_by(|e1, e2| e1.start.cmp(&e2.start) );
+
+    let mut pos = 0 as usize;
+    for entity in entities {
+        sb.push_all(&text[pos..entity.start]);
+        sb.push_all(&*entity.html);
+        pos = entity.end;
+    }
+    sb.push_all(&text[pos..text.len()]);
+    sb.into_iter().collect()
+}
+
 
 fn main() {
-	let result = classic(&mut entities());
-	println!("Result: {}", result);
+    let result = classic(&ASCII_TEXT.chars().collect(), &mut decoded_entities());
+    println!("Result: {}", result);
 }
 
-pub fn classic(entities: &mut Vec<Entity>) -> String {
-    render("Attend to hear 6 stellar #mobile #startups at #OF12 Entrepreneur Idol show 2day,  http://t.co/HtzEMgAC @TiEcon @sv_entrepreneur @500!", entities)
+
+pub fn classic_ascii(text: &str, entities: &mut Vec<Entity>) -> String {
+    unsafe {
+        render_ascii(text, entities)
+    }
+}
+
+pub fn classic(text: &Vec<char>, entities: &mut Vec<DecodedEntity>) -> String {
+    render(&text, entities)
 }
 
 pub fn entities() -> Vec<Entity> {
-	let entities = vec![
-	Entity {start: 82, end: 102, html:"<http://t.co/HtzEMgAC>".to_string()},
-	Entity {start: 128, end: 132, html:"<@500>".to_string()},
-	Entity {start: 25, end: 32, html:"<#mobile>".to_string()},
-	Entity {start: 33, end: 42, html:"<#startups>".to_string()},
-	Entity {start: 111, end: 127, html:"<@sv_entrepreneur>".to_string()},
-	Entity {start: 46, end: 51, html:"<#OF12>".to_string()},
-	Entity {start: 103, end: 110, html:"<@TiEcon>".to_string()},
-	];
-	entities
+    let entities = vec![
+    Entity {start: 82, end: 102, html:"<http://t.co/HtzEMgAC>".to_string()},
+    Entity {start: 128, end: 132, html:"<@500>".to_string()},
+    Entity {start: 25, end: 32, html:"<#mobile>".to_string()},
+    Entity {start: 33, end: 42, html:"<#startups>".to_string()},
+    Entity {start: 111, end: 127, html:"<@sv_entrepreneur>".to_string()},
+    Entity {start: 46, end: 51, html:"<#OF12>".to_string()},
+    Entity {start: 103, end: 110, html:"<@TiEcon>".to_string()},
+    ];
+    entities
+}
+
+pub fn decoded_entities() -> Vec<DecodedEntity> {
+    entities().into_iter().map( |e: Entity|
+        DecodedEntity {start: e.start, end: e.end, html: e.html.chars().collect()}
+    ).collect()
 }
 
 #[cfg(test)]
@@ -53,16 +92,31 @@ mod rendertest {
     use test::Bencher;
 
     #[test]
-	fn correctness() {
-		let result = "Attend to hear 6 stellar <#mobile> <#startups> at <#OF12> Entrepreneur Idol show 2day,  <http://t.co/HtzEMgAC> <@TiEcon> <@sv_entrepreneur> <@500>!";
-		assert_eq!(result, classic(&mut entities()))
-	}
+    fn correctness_ascii() {
+        let result = "Attend to hear 6 stellar <#mobile> <#startups> at <#OF12> Entrepreneur Idol show 2day,  <http://t.co/HtzEMgAC> <@TiEcon> <@sv_entrepreneur> <@500>!";
+        assert_eq!(result, classic_ascii(ASCII_TEXT, &mut entities()))
+    }
+
+    #[test]
+    fn correctness() {
+        let result = "Attend 次次 hear 6 stellar <#mobile> <#startups> at <#OF12> Entrepreneur Idol show 2day,  <http://t.co/HtzEMgAC> <@TiEcon> <@sv_entrepreneur> <@500>!";
+        assert_eq!(result, classic(&UNICODE_TEXT.chars().collect(), &mut decoded_entities()))
+    }
 
     #[bench]
-	fn bench_replacement(b: &mut Bencher) {
-	   	let entities = &mut entities();
-		b.iter(|| {
-		    classic(entities)
-		});
-	}
+    fn bench_replacement_ascii(b: &mut Bencher) {
+        let entities = &mut entities();
+        b.iter(|| {
+            classic_ascii(ASCII_TEXT, entities)
+        });
+    }
+
+    #[bench]
+    fn bench_replacement(b: &mut Bencher) {
+        let entities = &mut decoded_entities();
+        let decoded_text = UNICODE_TEXT.chars().collect();
+        b.iter(|| {
+            classic(&decoded_text, entities)
+        });
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,10 +12,9 @@ pub struct Entity {
     html: String
 }
 
-fn render(text: String, entities: &mut Vec<Entity>) -> String {
-	let mut mutentities = entities.to_vec();
+fn render(text: &str, entities: &mut Vec<Entity>) -> String {
 	let mut sb = String::new();
-	mutentities.sort_by(|e1, e2| if e1.start < e2.start {
+	entities.sort_by(|e1, e2| if e1.start < e2.start {
 		Ordering::Less
 	} else if e1.start > e2.start {
 		Ordering::Greater
@@ -23,7 +22,7 @@ fn render(text: String, entities: &mut Vec<Entity>) -> String {
 		Ordering::Equal
 	});
 	let mut pos = 0 as usize;
-	for entity in mutentities {
+	for entity in entities {
 		sb.push_str(text.slice_chars(pos, entity.start));
 		sb.push_str(entity.html.as_str());
 		pos = entity.end;
@@ -38,7 +37,7 @@ fn main() {
 }
 
 pub fn classic(entities: &mut Vec<Entity>) -> String {
-    render("Attend to hear 6 stellar #mobile #startups at #OF12 Entrepreneur Idol show 2day,  http://t.co/HtzEMgAC @TiEcon @sv_entrepreneur @500!".to_string(), entities)
+    render("Attend to hear 6 stellar #mobile #startups at #OF12 Entrepreneur Idol show 2day,  http://t.co/HtzEMgAC @TiEcon @sv_entrepreneur @500!", entities)
 }
 
 pub fn entities() -> Vec<Entity> {


### PR DESCRIPTION
Enticed by the Java vs Rust perf results, I did some experimenting.

First, by just removing some unneeded data copying (e.g. `.clone()`), I saw nearly 30% perf boost (bringing it almost on par with java).

After some experimentation, I noticed one statement was responsible for dragging down the perf: `text.slice_chars(pos, entity.start)`. For sport, I replaced it with the unsafe byte-based `slice_unchecked`, and it was nearly a 6x perf gain, but would misrender text that had non-ASCII chars. It also helped me discover that even the previous implementation could misrender or panic with non-ASCII chars because the statement `text.slice_chars(pos, text.len()` assumes `text.len()` returns the number of characters, but it actually returns the number of bytes. (surprised me).

And then I set off on a mission to support the full unicode space. I could have just replaced `text.len()` with `text.chars.count()`, but I wanted to avoid UTF-8 decoding inside the benchmark block, because the Java implementation doesn't pay that penalty during rendering. [If I understand correctly,] the Java implemenation uses UTF-16 and will happily render garbage for characters outside the BMP. Maybe that would be fine in some cases, but what good is a tweet if I can't use emoji? (Long live [emoji-lang](https://github.com/anowell/emoji-lang)!) So inevitably, a real Java implementation would have to deal with encoding/decoding more unicode codepoints, hence to achieve a more apples-to-apples comparison, I wanted to refactor the Rust benchmark to discount the time spent decoding UTF-8. 

The result is a classic renderer with full unicode support, that runs ~2.5x faster than Java. It's about half as fast as the ASCII implementation, but I did opt to use `Vec::push_all` which is marked `Unstable: likely to be replaced by a more optimized extend`. There is almost certainly room for improvement still, but I've hit my limit for now. :-D
