### PR TITLE
Randomize entities for bench, restore string-based codepoint impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,41 @@
 [root]
 name = "interviewcode"
 version = "0.0.1"
+dependencies = [
+ "rand 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "advapi32-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libc"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rand"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,6 @@
 name = "interviewcode"
 version = "0.0.1"
 authors = [ "Sam Pullara <sam@sampullara.com>" ]
+
+[dev-dependencies]
+rand = "*"

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,10 +78,8 @@ fn main() {
 }
 
 
-pub fn classic_ascii(text: &str, entities: &mut Vec<Entity>) -> String {
-    unsafe {
-        render_ascii(text, entities)
-    }
+pub unsafe fn classic_ascii(text: &str, entities: &mut Vec<Entity>) -> String {
+    render_ascii(text, entities)
 }
 
 pub fn classic(text: &str, entities: &mut Vec<Entity>) -> String {
@@ -157,7 +155,7 @@ mod rendertest {
     #[test]
     fn correctness_ascii() {
         let result = "Attend to hear 6 stellar <#mobile> <#startups> at <#OF12> Entrepreneur Idol show 2day,  <http://t.co/HtzEMgAC> <@TiEcon> <@sv_entrepreneur> <@500>!";
-        assert_eq!(result, classic_ascii(ASCII_TEXT, &mut entities()))
+        assert_eq!(result, unsafe { classic_ascii(ASCII_TEXT, &mut entities()) })
     }
 
     #[test]
@@ -177,7 +175,9 @@ mod rendertest {
         let mut entities_list = generate_entities();
         let mut index_iter = (0..1000).into_iter().cycle();
         b.iter(|| {
-            classic_ascii(ASCII_TEXT, &mut entities_list[index_iter.next().unwrap()])
+            unsafe {
+                classic_ascii(ASCII_TEXT, &mut entities_list[index_iter.next().unwrap()])
+                }
         });
     }
 


### PR DESCRIPTION
This probably should have been multiple commits, but I was a bit hasty.
- Ported the randomized entity generation used by the Java tests to Rust.
- Renamed classic to classic_chars (code points are pre-decoded before the benchmarking).
- Restored classic implementation that uses &str input and decodes code points as part of the benchmarked block. (Very similar to the original implementation). This should be suited for comparing with a Java implementation that uses code points.
- Added minor optimization for initial string/vec capacity in all cases to decrease reallocations (making it slightly more like the Java OptimizedClassic)

My results:

```
[Java]
Classic: 1067
Classic: 1023
Classic: 1054
OptimizedClassic: 777
OptimizedClassic: 725
OptimizedClassic: 721

[Rust]
classic       ... bench:       1,093 ns/iter (+/- 300)
classic_ascii ... bench:         176 ns/iter (+/- 18)
classic_chars ... bench:         540 ns/iter (+/- 168)
```
