### PR TITLE
Add another implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,15 +8,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fs_extra"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "interviewcode"
 version = "0.0.1"
 dependencies = [
+ "jemallocator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "jemalloc-sys 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libc"
 version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -41,7 +76,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "307c92332867e586720c0222ee9d890bbe8431711efed8a1b06bc5b40fc66bd7"
+"checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
+"checksum fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
+"checksum jemalloc-sys 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "bfc62c8e50e381768ce8ee0428ee53741929f7ebd73e4d83f669bcf7693e00ae"
+"checksum jemallocator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9f0cd42ac65f758063fea55126b0148b1ce0a6354ff78e07a4d6806bc65c4ab3"
 "checksum libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "cd70bd1f9f3bfadfdcdf92869faecc795686617d3a9acfe74d0c89a4bb6d142b"
+"checksum libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)" = "2d2857ec59fadc0773853c664d2d18e7198e83883e7060b63c924cb077bd5c74"
 "checksum rand 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ea766199c2c97314b1c1aa5c5084d0e85558e4bfadfbe657ee8cd61fecf7cda0"
 "checksum winapi 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fbd7cedf132c366b81f8d2a2d1ed104885c364183338adc2be8211f99ebd6ff1"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,8 @@ name = "interviewcode"
 version = "0.0.1"
 authors = [ "Sam Pullara <sam@sampullara.com>" ]
 
+[dependencies]
+jemallocator = "0.1.8"
+
 [dev-dependencies]
 rand = "*"

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,8 @@ impl Entity {
     }
 }
 
-fn render(text: &str, entities: &mut Vec<Entity>) -> String {
+fn render(text: &str, im_entities: &Vec<Entity>) -> String {
+    let mut entities = im_entities.to_vec();
     let mut sb = String::with_capacity(text.len()*2);
     entities.sort_by(|e1, e2| e1.start.cmp(&e2.start) );
 
@@ -57,7 +58,8 @@ fn render(text: &str, entities: &mut Vec<Entity>) -> String {
     sb
 }
 
-fn render_chars(text: &Vec<char>, entities: &mut Vec<DecodedEntity>) -> String {
+fn render_chars(text: &Vec<char>, im_entities: &Vec<DecodedEntity>) -> String {
+    let mut entities = im_entities.to_vec();
     let mut sb: Vec<char> = Vec::with_capacity(text.len()*2);
     entities.sort_by(|e1, e2| e1.start.cmp(&e2.start) );
 
@@ -71,7 +73,8 @@ fn render_chars(text: &Vec<char>, entities: &mut Vec<DecodedEntity>) -> String {
     sb.into_iter().collect()
 }
 
-fn render_chars_2(text: &Vec<char>, entities: &mut Vec<Entity>) -> String {
+fn render_chars_2(text: &Vec<char>, im_entities: &Vec<Entity>) -> String {
+    let mut entities = im_entities.to_vec();
     let mut sb = String::with_capacity(text.len()*2);
     entities.sort();
 
@@ -97,15 +100,15 @@ fn main() {
 }
 
 
-pub fn classic(text: &str, entities: &mut Vec<Entity>) -> String {
+pub fn classic(text: &str, entities: &Vec<Entity>) -> String {
     render(&text, entities)
 }
 
-pub fn classic_chars(text: &Vec<char>, entities: &mut Vec<DecodedEntity>) -> String {
+pub fn classic_chars(text: &Vec<char>, entities: &Vec<DecodedEntity>) -> String {
     render_chars(&text, entities)
 }
 
-pub fn classic_chars_2(text: &Vec<char>, entities: &mut Vec<Entity>) -> String {
+pub fn classic_chars_2(text: &Vec<char>, entities: &Vec<Entity>) -> String {
     render_chars_2(&text, entities)
 }
 
@@ -191,32 +194,32 @@ mod rendertest {
 
     #[bench]
     fn bench_replacement(b: &mut Bencher) {
-        let mut entities_list = generate_entities();
+        let entities_list = generate_entities();
         let mut index_iter = (0..1000).into_iter().cycle();
         b.iter(|| {
-            classic(UNICODE_TEXT, &mut entities_list[index_iter.next().unwrap()])
+            classic(UNICODE_TEXT, &entities_list[index_iter.next().unwrap()])
         });
     }
 
     #[bench]
     fn bench_replacement_chars(b: &mut Bencher) {
-        let mut entities_list = generate_decoded_entities();
+        let entities_list = generate_decoded_entities();
         let mut index_iter = (0..1000).into_iter().cycle();
         let decoded_text = UNICODE_TEXT.chars().collect();
         b.iter(|| {
             let option = index_iter.next();
-            classic_chars(&decoded_text, &mut entities_list[option.unwrap()])
+            classic_chars(&decoded_text, &entities_list[option.unwrap()])
         });
     }
 
     #[bench]
     fn bench_replacement_chars_2(b: &mut Bencher) {
-        let mut entities_list = generate_entities();
+        let entities_list = generate_entities();
         let mut index_iter = (0..1000).into_iter().cycle();
         let decoded_text = UNICODE_TEXT.chars().collect();
         b.iter(|| {
             let option = index_iter.next();
-            classic_chars_2(&decoded_text, &mut entities_list[option.unwrap()])
+            classic_chars_2(&decoded_text, &entities_list[option.unwrap()])
         });
     }
 }


### PR DESCRIPTION
This one is about twice as fast. Here's what I get:

git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
Roberts-MacBook-Pro:interviewcode sayrer$ cargo bench
   Compiling interviewcode v0.0.1 (/Users/sayrer/github/sayrer/interviewcode)
    Finished release [optimized] target(s) in 1.45s
     Running target/release/deps/interviewcode-51a03237c660108c

running 4 tests
test rendertest::correctness ... ignored
test rendertest::correctness_chars ... ignored
test rendertest::bench_replacement       ... bench:         905 ns/iter (+/- 103)
test rendertest::bench_replacement_chars ... bench:         788 ns/iter (+/- 68)

test result: ok. 0 passed; 0 failed; 2 ignored; 2 measured; 0 filtered out

Roberts-MacBook-Pro:interviewcode sayrer$ git checkout another_rust_implementation
Switched to branch 'another_rust_implementation'

Roberts-MacBook-Pro:interviewcode sayrer$ cargo test
    Finished dev [unoptimized + debuginfo] target(s) in 0.29s
     Running target/debug/deps/interviewcode-e3b1fa7d042a6ba4

running 6 tests
test rendertest::correctness ... ok
test rendertest::correctness_chars_2 ... ok
test rendertest::correctness_chars ... ok
test rendertest::bench_replacement ... ok
test rendertest::bench_replacement_chars_2 ... ok
test rendertest::bench_replacement_chars ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

Roberts-MacBook-Pro:interviewcode sayrer$ cargo bench
    Finished release [optimized] target(s) in 0.07s
     Running target/release/deps/interviewcode-a3911db0f8a6b90f

running 6 tests
test rendertest::correctness ... ignored
test rendertest::correctness_chars ... ignored
test rendertest::correctness_chars_2 ... ignored
test rendertest::bench_replacement         ... bench:         810 ns/iter (+/- 97)
test rendertest::bench_replacement_chars   ... bench:         616 ns/iter (+/- 144)
test rendertest::bench_replacement_chars_2 ... bench:         393 ns/iter (+/- 41)