### PR TITLE
Add a version that just returns a char array, add cost of calculating coordinates

### DIFF
--- a/rust-jemalloc/src/main.rs
+++ b/rust-jemalloc/src/main.rs
@@ -171,18 +171,8 @@ fn coordinates_to_utf8(coordinates: &Vec<Coord>, text: &Vec<char>, entities: &Ve
 }
 
 fn main() {
-    let result = "Attend \u{20000}\u{20000} hear 6 stellar <#mobile> <#startups> at <#OF12> Entrepreneur Idol show 2day,  <http://t.co/HtzEMgAC> <@TiEcon> <@sv_entrepreneur> <@500>!";
-    let mut chars: Vec<char> = Vec::new();
-
-    let text = &UNICODE_TEXT.chars().collect();
-    let decoded = &decoded_entities(entities());
-    let refs = &entity_refs(decoded);
-    for i in 0..10000000 {
-        chars = render_chars_entity_references_to_chars(text, refs);
-    }
-    
-    let s: String = chars.iter().collect();
-    println!("Result: {}", s);
+    let result = render(&ASCII_TEXT, &mut entities());
+    println!("Result: {}", result);
 }
 
 pub fn entities() -> Vec<Entity<String>> {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -21,16 +21,17 @@ impl PartialOrd for Entity<String> {
     }
 }
 
-#[derive(Clone)]
-pub struct DecodedEntity {
-    start: usize,
-    end: usize,
-    html: Vec<char>,
+type DecodedEntity = Entity<Vec<char>>;
+
+impl Ord for DecodedEntity {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.start.cmp(&other.start)
+    }
 }
 
-impl Entity<String> {
-    fn decode(&self) -> DecodedEntity {
-        DecodedEntity {start: self.start, end: self.end, html: self.html.chars().collect()}
+impl PartialOrd for DecodedEntity {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 
@@ -63,7 +64,7 @@ fn render_chars(text: &Vec<char>, entities: &Vec<DecodedEntity>) -> String {
         pos = entity.end;
     }
     sb.extend_from_slice(&text[pos..text.len()]);
-    sb.into_iter().collect()
+    sb.into_iter().collect() // <-- UTF-8 encoding
 }
 
 fn render_chars2(text: &Vec<char>, entities: &Vec<Entity<String>>) -> String {
@@ -106,6 +107,24 @@ fn render_chars_entity_references(text: &Vec<char>, entities: &Vec<&Entity<Strin
     sb
 }
 
+fn render_chars_entity_references_to_chars(text: &Vec<char>, entities: &Vec<&DecodedEntity>) -> Vec<char> {
+    let mut my_entities: Vec<&DecodedEntity> = Vec::with_capacity(entities.len());
+    for e in entities {
+        my_entities.push(e);
+    }
+    my_entities.sort();
+
+    let mut sb: Vec<char> = Vec::with_capacity(text.len()*2);
+    let mut pos = 0 as usize;
+    for entity in my_entities {
+        sb.extend_from_slice(&text[pos..entity.start]);
+        sb.extend_from_slice(&entity.html);
+        pos = entity.end;
+    }
+    sb.extend_from_slice(&text[pos..text.len()]);
+    sb
+}
+
 fn main() {
     let result = render(&ASCII_TEXT, &mut entities());
     println!("Result: {}", result);
@@ -124,11 +143,17 @@ pub fn entities() -> Vec<Entity<String>> {
     entities
 }
 
-pub fn decoded_entities() -> Vec<DecodedEntity> {
-    entities().into_iter().map( |e| e.decode() ).collect()
+pub fn decoded_entities(entities: Vec<Entity<String>>) -> Vec<DecodedEntity> {
+    entities.iter().map( |e| {
+        DecodedEntity {
+            start: e.start,
+            end: e.end,
+            html: e.html.chars().collect()
+        }
+    } ).collect()
 }
 
-pub fn entity_refs<'a>(entities: &'a Vec<Entity<String>>) -> Vec<&'a Entity<String>> {
+pub fn entity_refs<'a, T>(entities: &'a Vec<T>) -> Vec<&'a T> {
     entities.into_iter().map( |e| e ).collect()
 }
 
@@ -174,14 +199,14 @@ mod rendertest {
 
     fn generate_decoded_entities() -> Vec<Vec<DecodedEntity>> {
         generate_entities().into_iter().map(|entries| {
-            entries.into_iter().map(|e| { e.decode() } ).collect()
+            decoded_entities(entries)
         }).collect()
     }
 
     #[test]
     fn correctness_chars() {
         let result = "Attend \u{20000}\u{20000} hear 6 stellar <#mobile> <#startups> at <#OF12> Entrepreneur Idol show 2day,  <http://t.co/HtzEMgAC> <@TiEcon> <@sv_entrepreneur> <@500>!";
-        assert_eq!(result, render_chars(&UNICODE_TEXT.chars().collect(), &decoded_entities()))
+        assert_eq!(result, render_chars(&UNICODE_TEXT.chars().collect(), &decoded_entities(entities())))
     }
 
     #[test]
@@ -202,6 +227,14 @@ mod rendertest {
         assert_eq!(result, render_chars_entity_references(&UNICODE_TEXT.chars().collect(), &entity_refs(&entities())))
     }
 
+    #[test]
+    fn correctness_chars_entity_reference_to_chars() {
+        let result = "Attend \u{20000}\u{20000} hear 6 stellar <#mobile> <#startups> at <#OF12> Entrepreneur Idol show 2day,  <http://t.co/HtzEMgAC> <@TiEcon> <@sv_entrepreneur> <@500>!";
+        let chars = render_chars_entity_references_to_chars(&UNICODE_TEXT.chars().collect(), &entity_refs(&decoded_entities(entities())));
+        let s: String = chars.iter().collect();
+        assert_eq!(result, s);
+    }
+
     #[bench]
     fn bench_replacement(b: &mut Bencher) {
         let entities_list = generate_entities();
@@ -218,7 +251,7 @@ mod rendertest {
         let decoded_text = UNICODE_TEXT.chars().collect();
         b.iter(|| {
             let option = index_iter.next();
-            render_chars(&decoded_text, &entities_list[option.unwrap()].clone())
+            render_chars(&decoded_text, &entities_list[option.unwrap()])
         });
     }
 
@@ -245,6 +278,21 @@ mod rendertest {
         b.iter(|| {
             let option = index_iter.next();
             render_chars_entity_references(&decoded_text, &refs[option.unwrap()])
+        });
+    }
+
+    #[bench]
+    fn bench_replacement_chars_entity_references_to_chars(b: &mut Bencher) {
+        let entities_list = generate_decoded_entities();
+        let mut refs = Vec::with_capacity(1000);
+        for (i, _) in entities_list.iter().enumerate() {
+            refs.push(entity_refs(&entities_list[i]));
+        }
+        let mut index_iter = (0..1000).into_iter().cycle();
+        let decoded_text = UNICODE_TEXT.chars().collect();
+        b.iter(|| {
+            let option = index_iter.next();
+            render_chars_entity_references_to_chars(&decoded_text, &refs[option.unwrap()])
         });
     }
 }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -167,18 +167,8 @@ fn coordinates_to_utf8(coordinates: &Vec<Coord>, text: &Vec<char>, entities: &Ve
 }
 
 fn main() {
-    let result = "Attend \u{20000}\u{20000} hear 6 stellar <#mobile> <#startups> at <#OF12> Entrepreneur Idol show 2day,  <http://t.co/HtzEMgAC> <@TiEcon> <@sv_entrepreneur> <@500>!";
-    let mut chars: Vec<char> = Vec::new();
-
-    let text = &UNICODE_TEXT.chars().collect();
-    let decoded = &decoded_entities(entities());
-    let refs = &entity_refs(decoded);
-    for i in 0..10000000 {
-        chars = render_chars_entity_references_to_chars(text, refs);
-    }
-    
-    let s: String = chars.iter().collect();
-    println!("Result: {}", s);
+    let result = render(&ASCII_TEXT, &mut entities());
+    println!("Result: {}", result);
 }
 
 pub fn entities() -> Vec<Entity<String>> {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -15,6 +15,7 @@ impl Ord for Entity<String> {
         self.start.cmp(&other.start)
     }
 }
+
 impl PartialOrd for Entity<String> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
@@ -112,7 +113,7 @@ fn render_chars_entity_references_to_chars(text: &Vec<char>, entities: &Vec<&Dec
     for e in entities {
         my_entities.push(e);
     }
-    my_entities.sort();
+    my_entities.sort_unstable();
 
     let mut sb: Vec<char> = Vec::with_capacity(text.len()*2);
     let mut pos = 0 as usize;
@@ -125,9 +126,59 @@ fn render_chars_entity_references_to_chars(text: &Vec<char>, entities: &Vec<&Dec
     sb
 }
 
+#[derive(Copy, Clone, Debug)]
+struct Coord {
+    start: usize,
+    end: usize,
+}
+
+fn render_coords(coordinates: &mut Vec<Coord>, text: &Vec<char>, entities: &Vec<&DecodedEntity>)  {
+    let mut pos = 0 as usize;
+    for entity in entities {
+        coordinates.push(Coord{start: pos, end: entity.start});
+        coordinates.push(Coord{start: 0, end: entity.html.len()});
+        pos = entity.end;
+    }
+    coordinates.push(Coord{start: pos, end: text.len()});
+}
+
+fn coordinates_to_utf8(coordinates: &Vec<Coord>, text: &Vec<char>, entities: &Vec<&DecodedEntity>) -> String {
+    let mut sb = String::with_capacity(text.len()*2);
+    let mut in_entity = false;
+    let mut entity_index = 0;
+
+    let mut source: &Vec<char> = text;
+
+    for coord in coordinates {
+        if in_entity {
+            source = &entities[entity_index].html;
+            entity_index += 1;
+        } else {
+            source = text;
+        }
+
+        for i in coord.start..coord.end {
+            sb.push(source[i]);
+        }
+        in_entity = !in_entity;
+    }
+
+    sb
+}
+
 fn main() {
-    let result = render(&ASCII_TEXT, &mut entities());
-    println!("Result: {}", result);
+    let result = "Attend \u{20000}\u{20000} hear 6 stellar <#mobile> <#startups> at <#OF12> Entrepreneur Idol show 2day,  <http://t.co/HtzEMgAC> <@TiEcon> <@sv_entrepreneur> <@500>!";
+    let mut chars: Vec<char> = Vec::new();
+
+    let text = &UNICODE_TEXT.chars().collect();
+    let decoded = &decoded_entities(entities());
+    let refs = &entity_refs(decoded);
+    for i in 0..10000000 {
+        chars = render_chars_entity_references_to_chars(text, refs);
+    }
+    
+    let s: String = chars.iter().collect();
+    println!("Result: {}", s);
 }
 
 pub fn entities() -> Vec<Entity<String>> {
@@ -235,6 +286,32 @@ mod rendertest {
         assert_eq!(result, s);
     }
 
+    #[test]
+    fn correctness_render_steps() {
+        let result = "Attend \u{20000}\u{20000} hear 6 stellar <#mobile> <#startups> at <#OF12> Entrepreneur Idol show 2day,  <http://t.co/HtzEMgAC> <@TiEcon> <@sv_entrepreneur> <@500>!";
+
+        // Decode from UTF-8
+        let decoded = &decoded_entities(entities());
+        let refs = &entity_refs(decoded);
+        let text = &UNICODE_TEXT.chars().collect();
+
+        // Sort entities
+        let mut sorted: Vec<&DecodedEntity> = Vec::with_capacity(refs.len());
+        for e in refs {
+            sorted.push(e);
+        }
+        sorted.sort_unstable();
+
+        // Render coordinates
+        let mut ht = Vec::with_capacity(64);
+        render_coords(&mut ht, text, &sorted);
+
+        // Encode to UTF-8
+        let s = coordinates_to_utf8(&ht, text, &sorted);
+
+        assert_eq!(result, s);
+    }
+
     #[bench]
     fn bench_replacement(b: &mut Bencher) {
         let entities_list = generate_entities();
@@ -293,6 +370,32 @@ mod rendertest {
         b.iter(|| {
             let option = index_iter.next();
             render_chars_entity_references_to_chars(&decoded_text, &refs[option.unwrap()])
+        });
+    }
+
+    // Benchmark only sorting entities and determining substitutions.
+    #[bench]
+    fn bench_render_coords(b: &mut Bencher) {
+        let entities_list = generate_decoded_entities();
+        let mut refs = Vec::with_capacity(1000);
+        for (i, _) in entities_list.iter().enumerate() {
+            refs.push(entity_refs(&entities_list[i]));
+        }
+        let mut index_iter = (0..1000).into_iter().cycle();
+        let decoded_text = UNICODE_TEXT.chars().collect();
+        let mut ht = Vec::with_capacity(64);
+
+        b.iter(|| {
+            let option = index_iter.next();
+            ht.clear();
+            // Sort entities
+            let refs = &refs[option.unwrap()];
+            let mut sorted: Vec<&DecodedEntity> = Vec::with_capacity(refs.len());
+            for e in refs {
+                sorted.push(e);
+            }
+            sorted.sort_unstable();
+            render_coords(&mut ht, &decoded_text, &sorted);
         });
     }
 }


### PR DESCRIPTION
I noticed the Rust versions were incurring a cost converting its return value to a UTF-8 string, whereas the C++ leaves its results in UTF-32. This adds a version that's comparable. I also added a comment to render_chars noting that it's performing this costly conversion.

I added another test here, called bench_render_coords. It covers steps 2 and 3 below, but not the encoding/decoding required by step 1 and 4.

This problem requires four steps:

1) Decode the text and entities from a source format (probably UTF-8) to whatever format the entity offsets reflect. In this benchmark, they are said to be UTF-32, but I think Twitter actually uses UTF-16 offsets (https://github.com/twitter/twitter-text/blob/9537bdf15f935b40fed0ea3ea44cee860fbb8880/java/src/main/java/com/twitter/twittertext/TwitterTextParser.java#L190). Edit: or, maybe, the text ranges are in UTF-16 but the entity positions are in UTF-32? Confusing, but they are definitely not UTF-8 byte positions.

2) Sort the entities, this is pretty much the same no matter what the offsets reflect.

3) Determine the entity positions within the source text. This function is called "render_coords" in this patch. There's no need to copy byte buffers during this step.

4) Encode the result to a wire format (probably UTF-8). The fastest C++ and Rust versions don't count step 1 in the bench, and don't bother re-encoding to UTF-8 during this step.

If the entity offsets were UTF-8 byte offsets, it would be easy enough to produce the result without ever allocating anything in step 4. This would be nicest to work with in languages where the string type is UTF-8 (Rust, Go, etc).

rust-jemalloc:
test rendertest::bench_render_coords                                ... bench:          58 ns/iter (+/- 7)
test rendertest::bench_replacement                                  ... bench:         969 ns/iter (+/- 245)
test rendertest::bench_replacement_chars                            ... bench:         808 ns/iter (+/- 49)
test rendertest::bench_replacement_chars2                           ... bench:         586 ns/iter (+/- 48)
test rendertest::bench_replacement_chars_entity_references          ... bench:         392 ns/iter (+/- 88)
test rendertest::bench_replacement_chars_entity_references_to_chars ... bench:         211 ns/iter (+/- 31)
rust:
test rendertest::bench_render_coords                                ... bench:         132 ns/iter (+/- 15)
test rendertest::bench_replacement                                  ... bench:       1,612 ns/iter (+/- 138)
test rendertest::bench_replacement_chars                            ... bench:       1,507 ns/iter (+/- 112)
test rendertest::bench_replacement_chars2                           ... bench:       1,186 ns/iter (+/- 80)
test rendertest::bench_replacement_chars_entity_references          ... bench:         553 ns/iter (+/- 77)
test rendertest::bench_replacement_chars_entity_references_to_chars ... bench:         335 ns/iter (+/- 39)